### PR TITLE
Develop

### DIFF
--- a/lib/features/auth/domain/usecases/sign_out_usecase.dart
+++ b/lib/features/auth/domain/usecases/sign_out_usecase.dart
@@ -1,0 +1,11 @@
+import '../repositories/auth_repository.dart';
+
+class SignOutUseCase {
+  final AuthRepository repository;
+
+  SignOutUseCase(this.repository);
+
+  Future<void> call() {
+    return repository.signOut();
+  }
+}

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,15 +1,27 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../../domain/repositories/auth_repository.dart';
+import '../../domain/usecases/sign_in_usecase.dart';
+import '../../domain/usecases/sign_up_usecase.dart';
+import '../../domain/usecases/sign_out_usecase.dart';
+import '../../domain/usecases/get_current_user_usecase.dart';
 import 'auth_event.dart';
 import '../state/auth_state.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
-  final AuthRepository authRepository;
-  AuthBloc(this.authRepository) : super(AuthInitial()) {
+  final SignInUseCase signInUseCase;
+  final SignUpUseCase signUpUseCase;
+  final SignOutUseCase signOutUseCase;
+  final GetCurrentUserUseCase getCurrentUserUseCase;
+
+  AuthBloc({
+    required this.signInUseCase,
+    required this.signUpUseCase,
+    required this.signOutUseCase,
+    required this.getCurrentUserUseCase,
+  }) : super(AuthInitial()) {
     on<AuthSignInRequested>((event, emit) async {
       emit(AuthLoading());
       try {
-        final user = await authRepository.signIn(event.email, event.password);
+        final user = await signInUseCase(event.email, event.password);
         if (user != null) {
           emit(AuthAuthenticated(user));
         } else {
@@ -22,11 +34,8 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthSignUpRequested>((event, emit) async {
       emit(AuthLoading());
       try {
-        await authRepository.signUp(event.user, event.password);
-        final user = await authRepository.signIn(
-          event.user.email,
-          event.password,
-        );
+        await signUpUseCase(event.user, event.password);
+        final user = await signInUseCase(event.user.email, event.password);
         if (user != null) {
           emit(AuthAuthenticated(user));
         } else {
@@ -39,7 +48,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthSignOutRequested>((event, emit) async {
       emit(AuthLoading());
       try {
-        await authRepository.signOut();
+        await signOutUseCase();
         emit(AuthUnauthenticated());
       } catch (e) {
         emit(AuthError(e.toString()));
@@ -48,7 +57,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     on<AuthCheckRequested>((event, emit) async {
       emit(AuthLoading());
       try {
-        final user = await authRepository.getCurrentUser();
+        final user = await getCurrentUserUseCase();
         if (user != null) {
           emit(AuthAuthenticated(user));
         } else {

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../state/auth_state.dart';
-import 'profile_screen.dart';
+import '../../../chat/presentation/screens/home_screen.dart';
 import 'register_screen.dart';
 import '../widgets/auth_text_field.dart';
 import '../widgets/auth_header.dart';
@@ -37,7 +37,7 @@ class _LoginScreenState extends State<LoginScreen> {
           if (state is AuthAuthenticated) {
             Navigator.pushReplacement(
               context,
-              MaterialPageRoute(builder: (_) => const ProfileScreen()),
+              MaterialPageRoute(builder: (_) => const HomeScreen()),
             );
           } else if (state is AuthError) {
             ScaffoldMessenger.of(

--- a/lib/features/auth/presentation/screens/splash_screen.dart
+++ b/lib/features/auth/presentation/screens/splash_screen.dart
@@ -5,7 +5,7 @@ import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../state/auth_state.dart';
 import 'login_screen.dart';
-import 'profile_screen.dart';
+import '../../../chat/presentation/screens/home_screen.dart';
 
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
@@ -34,7 +34,7 @@ class _SplashScreenState extends State<SplashScreen> {
             if (!mounted) return;
             Navigator.pushReplacement(
               context,
-              MaterialPageRoute(builder: (_) => const ProfileScreen()),
+              MaterialPageRoute(builder: (_) => const HomeScreen()),
             );
           });
         } else if (state is AuthUnauthenticated || state is AuthError) {

--- a/lib/features/chat/presentation/screens/home_screen.dart
+++ b/lib/features/chat/presentation/screens/home_screen.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_app_chat/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:flutter_app_chat/features/auth/presentation/bloc/auth_event.dart';
+import 'package:flutter_app_chat/features/auth/presentation/state/auth_state.dart';
+import 'package:flutter_app_chat/shared/widgets/app_drawer.dart';
+import 'package:flutter_app_chat/shared/widgets/chat_list_empty.dart';
+import 'package:flutter_app_chat/shared/widgets/chat_list_tile.dart';
+import 'package:flutter_app_chat/shared/widgets/confirm_dialog.dart';
+
+import 'package:flutter_app_chat/features/auth/presentation/screens/login_screen.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  int _selectedIndex = 0;
+  final List<Map<String, dynamic>> chats = [];
+
+  Future<void> _handleSignOut() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => const ConfirmDialog(
+        title: 'Sign Out',
+        content: 'Are you sure you want to sign out?',
+        confirmText: 'Sign Out',
+        cancelText: 'Cancel',
+      ),
+    );
+    if (confirmed == true) {
+      context.read<AuthBloc>().add(AuthSignOutRequested());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthUnauthenticated) {
+          Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(builder: (_) => const LoginScreen()),
+          );
+        }
+      },
+      child: Scaffold(
+        drawer: AppDrawer(onSignOut: _handleSignOut),
+        appBar: AppBar(
+          title: const Text('Secret Chat'),
+          centerTitle: true,
+          leading: Builder(
+            builder: (context) => IconButton(
+              icon: CircleAvatar(
+                backgroundImage: AssetImage('assets/avatar.png'),
+                radius: 16,
+              ),
+              onPressed: () => Scaffold.of(context).openDrawer(),
+            ),
+          ),
+          actions: [IconButton(icon: const Icon(Icons.edit), onPressed: () {})],
+        ),
+        body: _selectedIndex == 0 ? _buildChatList() : _buildMentions(),
+        bottomNavigationBar: BottomNavigationBar(
+          currentIndex: _selectedIndex,
+          onTap: (i) => setState(() => _selectedIndex = i),
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.chat_bubble_outline),
+              label: 'Chats',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.alternate_email),
+              label: 'Mentions',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatList() {
+    if (chats.isEmpty) {
+      return ChatListEmpty(onStartChat: () {});
+    }
+    return ListView.builder(
+      itemCount: chats.length,
+      itemBuilder: (context, index) {
+        final chat = chats[index];
+        return ChatListTile(
+          name: chat['name'] ?? '',
+          lastMessage: chat['lastMessage'] ?? '',
+          time: chat['time'] ?? '',
+          onTap: () {},
+        );
+      },
+    );
+  }
+
+  Widget _buildMentions() {
+    return const Center(child: Text('Mentions'));
+  }
+}

--- a/lib/features/chat/presentation/screens/home_screen.dart
+++ b/lib/features/chat/presentation/screens/home_screen.dart
@@ -31,6 +31,7 @@ class _HomeScreenState extends State<HomeScreen> {
         cancelText: 'Cancel',
       ),
     );
+    if (!mounted) return;
     if (confirmed == true) {
       context.read<AuthBloc>().add(AuthSignOutRequested());
     }
@@ -48,10 +49,7 @@ class _HomeScreenState extends State<HomeScreen> {
         }
       },
       child: Scaffold(
-        drawer: AppDrawer(
-          onSignOut: _handleSignOut,
-          userName: 'Andrew Jones', // TODO: truyền user động
-        ),
+        drawer: AppDrawer(onSignOut: _handleSignOut, userName: 'Andrew Jones'),
         appBar: AppBar(
           title: const Text('Secret Chat'),
           centerTitle: true,

--- a/lib/features/chat/presentation/screens/home_screen.dart
+++ b/lib/features/chat/presentation/screens/home_screen.dart
@@ -48,14 +48,17 @@ class _HomeScreenState extends State<HomeScreen> {
         }
       },
       child: Scaffold(
-        drawer: AppDrawer(onSignOut: _handleSignOut),
+        drawer: AppDrawer(
+          onSignOut: _handleSignOut,
+          userName: 'Andrew Jones', // TODO: truyền user động
+        ),
         appBar: AppBar(
           title: const Text('Secret Chat'),
           centerTitle: true,
           leading: Builder(
             builder: (context) => IconButton(
               icon: CircleAvatar(
-                backgroundImage: AssetImage('assets/avatar.png'),
+                backgroundImage: AssetImage(kDefaultAvatarAsset),
                 radius: 16,
               ),
               onPressed: () => Scaffold.of(context).openDrawer(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,10 @@ import 'package:flutter_app_chat/features/auth/data/repositories/auth_repository
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'features/auth/presentation/bloc/auth_bloc.dart';
 import 'features/auth/presentation/screens/splash_screen.dart';
+import 'features/auth/domain/usecases/sign_in_usecase.dart';
+import 'features/auth/domain/usecases/sign_up_usecase.dart';
+import 'features/auth/domain/usecases/sign_out_usecase.dart';
+import 'features/auth/domain/usecases/get_current_user_usecase.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -26,8 +30,19 @@ class MyApp extends StatelessWidget {
       ),
     );
 
+    // Usecases
+    final signInUseCase = SignInUseCase(authRepository);
+    final signUpUseCase = SignUpUseCase(authRepository);
+    final signOutUseCase = SignOutUseCase(authRepository);
+    final getCurrentUserUseCase = GetCurrentUserUseCase(authRepository);
+
     return BlocProvider<AuthBloc>(
-      create: (_) => AuthBloc(authRepository),
+      create: (_) => AuthBloc(
+        signInUseCase: signInUseCase,
+        signUpUseCase: signUpUseCase,
+        signOutUseCase: signOutUseCase,
+        getCurrentUserUseCase: getCurrentUserUseCase,
+      ),
       child: MaterialApp(
         title: 'Flutter Demo',
         theme: ThemeData(

--- a/lib/shared/widgets/app_drawer.dart
+++ b/lib/shared/widgets/app_drawer.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class AppDrawer extends StatelessWidget {
+  final VoidCallback? onSignOut;
+  const AppDrawer({super.key, this.onSignOut});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                children: [
+                  CircleAvatar(
+                    radius: 28,
+                    backgroundImage: AssetImage('assets/avatar.png'),
+                  ),
+                  const SizedBox(width: 12),
+                  const Text(
+                    'Andrew Jones',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(),
+            ListTile(
+              leading: const Icon(Icons.edit),
+              title: const Text('New Direct Message'),
+              onTap: () {},
+            ),
+            ListTile(
+              leading: const Icon(Icons.group),
+              title: const Text('New Group'),
+              onTap: () {},
+            ),
+            const Spacer(),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Sign Out'),
+              onTap: onSignOut,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/app_drawer.dart
+++ b/lib/shared/widgets/app_drawer.dart
@@ -1,8 +1,10 @@
+import 'chat_list_tile.dart';
 import 'package:flutter/material.dart';
 
 class AppDrawer extends StatelessWidget {
   final VoidCallback? onSignOut;
-  const AppDrawer({super.key, this.onSignOut});
+  final String userName;
+  const AppDrawer({super.key, this.onSignOut, required this.userName});
 
   @override
   Widget build(BuildContext context) {
@@ -17,12 +19,15 @@ class AppDrawer extends StatelessWidget {
                 children: [
                   CircleAvatar(
                     radius: 28,
-                    backgroundImage: AssetImage('assets/avatar.png'),
+                    backgroundImage: AssetImage(kDefaultAvatarAsset),
                   ),
                   const SizedBox(width: 12),
-                  const Text(
-                    'Andrew Jones',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
+                  Text(
+                    userName,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
                   ),
                 ],
               ),

--- a/lib/shared/widgets/chat_list_empty.dart
+++ b/lib/shared/widgets/chat_list_empty.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class ChatListEmpty extends StatelessWidget {
+  final VoidCallback? onStartChat;
+  const ChatListEmpty({super.key, this.onStartChat});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.chat_bubble_outline, size: 80, color: Colors.grey[300]),
+          const SizedBox(height: 16),
+          const Text("Let's start chatting!", style: TextStyle(fontSize: 18)),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: onStartChat,
+            child: const Text(
+              'Start a chat',
+              style: TextStyle(color: Colors.blue, fontWeight: FontWeight.bold),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/chat_list_tile.dart
+++ b/lib/shared/widgets/chat_list_tile.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+const String kDefaultAvatarAsset = 'assets/avatar.png';
+
 class ChatListTile extends StatelessWidget {
   final String name;
   final String lastMessage;
@@ -16,7 +18,7 @@ class ChatListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: CircleAvatar(backgroundImage: AssetImage('assets/avatar.png')),
+      leading: CircleAvatar(backgroundImage: AssetImage(kDefaultAvatarAsset)),
       title: Text(name),
       subtitle: Text(lastMessage),
       trailing: Text(time),

--- a/lib/shared/widgets/chat_list_tile.dart
+++ b/lib/shared/widgets/chat_list_tile.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+class ChatListTile extends StatelessWidget {
+  final String name;
+  final String lastMessage;
+  final String time;
+  final VoidCallback? onTap;
+  const ChatListTile({
+    super.key,
+    required this.name,
+    required this.lastMessage,
+    required this.time,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: CircleAvatar(backgroundImage: AssetImage('assets/avatar.png')),
+      title: Text(name),
+      subtitle: Text(lastMessage),
+      trailing: Text(time),
+      onTap: onTap,
+    );
+  }
+}

--- a/lib/shared/widgets/confirm_dialog.dart
+++ b/lib/shared/widgets/confirm_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class ConfirmDialog extends StatelessWidget {
+  final String title;
+  final String content;
+  final String confirmText;
+  final String cancelText;
+  final VoidCallback? onConfirm;
+
+  const ConfirmDialog({
+    super.key,
+    required this.title,
+    required this.content,
+    this.confirmText = 'OK',
+    this.cancelText = 'Cancel',
+    this.onConfirm,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(cancelText),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).pop(true);
+            if (onConfirm != null) onConfirm!();
+          },
+          child: Text(confirmText),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces major improvements to the authentication flow and the chat UI. It refactors the authentication logic to use dedicated use case classes, adds a new `HomeScreen` as the main post-login screen, and implements several reusable UI widgets for chat features and dialogs. The navigation after authentication has also been updated to direct users to the new `HomeScreen`.

**Authentication architecture refactor:**

* Refactored `AuthBloc` to use separate use case classes (`SignInUseCase`, `SignUpUseCase`, `SignOutUseCase`, `GetCurrentUserUseCase`) instead of directly depending on the repository, improving separation of concerns and testability.
* Added the new `SignOutUseCase` class to encapsulate the sign-out logic.

**Navigation and screen updates:**

* Replaced navigation to `ProfileScreen` with the new `HomeScreen` after successful authentication in both `LoginScreen` and `SplashScreen`.
* Added `HomeScreen` as the main chat screen, featuring a drawer, chat list, mentions tab, and sign-out confirmation dialog.

**New reusable UI components:**

* Added `AppDrawer` widget for navigation and sign-out, displaying the user's name and avatar.
* Added `ChatListEmpty` widget to display an empty state when there are no chats.
* Added `ChatListTile` widget for displaying individual chat entries, with a default avatar asset.
* Added `ConfirmDialog` widget for reusable confirmation dialogs, used for sign-out confirmation.