### PR TITLE
Feature/checkemail

### DIFF
--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -1,0 +1,3 @@
+class AppConfig {
+  static const String backendBaseUrl = 'http://10.0.2.2:3000';
+}

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -1,3 +1,6 @@
 class AppConfig {
-  static const String backendBaseUrl = 'http://10.0.2.2:3000';
+  static const String backendBaseUrl = String.fromEnvironment(
+    'BACKEND_BASE_URL',
+    defaultValue: 'http://10.0.2.2:3000',
+  );
 }

--- a/lib/features/auth/presentation/models/otp_args.dart
+++ b/lib/features/auth/presentation/models/otp_args.dart
@@ -1,0 +1,15 @@
+class OtpArgs {
+  final String email;
+  final String? password;
+  final String? username;
+  final String? phoneNumber;
+  final String? birthDate;
+
+  OtpArgs({
+    required this.email,
+    this.password,
+    this.username,
+    this.phoneNumber,
+    this.birthDate,
+  });
+}

--- a/lib/features/auth/presentation/screens/otp_input_screen.dart
+++ b/lib/features/auth/presentation/screens/otp_input_screen.dart
@@ -1,0 +1,263 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_app_chat/shared/services/otp_service.dart';
+import 'package:flutter_app_chat/core/config.dart';
+import '../models/otp_args.dart';
+
+class OtpInputScreen extends StatefulWidget {
+  final void Function(String otp)? onConfirm;
+
+  const OtpInputScreen({Key? key, this.onConfirm}) : super(key: key);
+
+  @override
+  State<OtpInputScreen> createState() => _OtpInputScreenState();
+}
+
+class _OtpInputScreenState extends State<OtpInputScreen> {
+  static const int _length = 6;
+
+  late final List<TextEditingController> _controllers;
+  late final List<FocusNode> _focusNodes;
+  bool _isResending = false;
+  int _resendCooldown = 0;
+  bool _isConfirming = false;
+  late final OtpService _otpService;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = List.generate(_length, (_) => TextEditingController());
+    _focusNodes = List.generate(_length, (_) => FocusNode());
+    _otpService = OtpService(AppConfig.backendBaseUrl);
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers) {
+      c.dispose();
+    }
+    for (final f in _focusNodes) {
+      f.dispose();
+    }
+    super.dispose();
+  }
+
+  void _startResendCooldown([int seconds = 30]) {
+    if (!mounted) return;
+    setState(() {
+      _resendCooldown = seconds;
+      _isResending = true;
+    });
+
+    Future.doWhile(() async {
+      await Future.delayed(const Duration(seconds: 1));
+      if (!mounted) return false;
+      setState(() => _resendCooldown--);
+      if (_resendCooldown <= 0) {
+        setState(() => _isResending = false);
+        return false;
+      }
+      return true;
+    });
+  }
+
+  void _handlePaste(String text) {
+    final digits = text.replaceAll(RegExp(r'\D'), '');
+    if (digits.length >= _length) {
+      for (var i = 0; i < _length; i++) {
+        _controllers[i].text = digits[i];
+      }
+      _submit();
+    }
+  }
+
+  void _submit() {
+    final otp = _controllers.map((c) => c.text).join();
+    if (otp.length == _length) {
+      _confirmOtp(otp);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter the full code')),
+      );
+    }
+  }
+
+  Future<void> _confirmOtp(String otp) async {
+    if (_isConfirming) return;
+    setState(() => _isConfirming = true);
+    final email = _readEmailFromArgs(context);
+    try {
+      final res = await _otpService.verifyOtp(email, otp);
+      if (res['ok'] == true) {
+        if (widget.onConfirm != null) widget.onConfirm!(otp);
+        if (mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('OTP verified')));
+        }
+      } else {
+        final reason = res['reason'] ?? 'unknown';
+        final message = res['message'] ?? 'Verification failed';
+        if (mounted) {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(SnackBar(content: Text('$message')));
+        }
+        if (reason == 'expired') {}
+      }
+    } catch (e) {
+      if (mounted)
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error: $e')));
+    } finally {
+      if (mounted) setState(() => _isConfirming = false);
+    }
+  }
+
+  String _readEmailFromArgs(BuildContext context) {
+    final args = ModalRoute.of(context)?.settings.arguments;
+    if (args is OtpArgs) return args.email;
+    if (args is String) return args;
+    if (args is Map) return args['email']?.toString() ?? '';
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final email = _readEmailFromArgs(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Enter Verification Code')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 8),
+              const Icon(
+                Icons.lock_outline,
+                size: 64,
+                color: Color(0xFF377DFF),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Verification Code',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                email.isNotEmpty
+                    ? 'Code sent to $email'
+                    : 'We have sent the verification code to your email address',
+                style: const TextStyle(fontSize: 14, color: Colors.black54),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: List.generate(_length, (index) {
+                  return SizedBox(
+                    width: 48,
+                    child: TextField(
+                      controller: _controllers[index],
+                      focusNode: _focusNodes[index],
+                      textAlign: TextAlign.center,
+                      keyboardType: TextInputType.number,
+                      maxLength: 1,
+                      inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                      decoration: InputDecoration(
+                        counterText: '',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                      onChanged: (v) {
+                        if (v.isNotEmpty) {
+                          if (index + 1 < _length) {
+                            _focusNodes[index + 1].requestFocus();
+                          } else {
+                            _focusNodes[index].unfocus();
+                            _submit();
+                          }
+                        } else {
+                          // user deleted the char -> move focus back
+                          if (index - 1 >= 0)
+                            _focusNodes[index - 1].requestFocus();
+                        }
+                      },
+                      onTap: () async {
+                        // quick paste detection: if clipboard contains 6 digits, auto-fill
+                        final data = await Clipboard.getData('text/plain');
+                        final text = data?.text ?? '';
+                        if (text.replaceAll(RegExp(r'\D'), '').length >=
+                            _length) {
+                          _handlePaste(text);
+                        }
+                      },
+                    ),
+                  );
+                }),
+              ),
+
+              const SizedBox(height: 28),
+
+              ElevatedButton(
+                onPressed: _isConfirming ? null : _submit,
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                ),
+                child: _isConfirming
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : const Text('Confirm', style: TextStyle(fontSize: 16)),
+              ),
+
+              const SizedBox(height: 12),
+
+              TextButton(
+                onPressed: _isResending
+                    ? null
+                    : () async {
+                        final email = _readEmailFromArgs(context);
+                        if (email.isEmpty) return;
+                        setState(() => _isResending = true);
+                        try {
+                          await _otpService.sendOtp(email);
+                          if (mounted)
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('OTP resent')),
+                            );
+                          _startResendCooldown(30);
+                        } catch (e) {
+                          if (mounted)
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Resend failed: $e')),
+                            );
+                        } finally {
+                          if (mounted) setState(() => _isResending = false);
+                        }
+                      },
+                child: Text(
+                  _isResending ? 'Resend ($_resendCooldown)' : 'Resend code',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/otp_input_screen.dart
+++ b/lib/features/auth/presentation/screens/otp_input_screen.dart
@@ -103,7 +103,16 @@ class _OtpInputScreenState extends State<OtpInputScreen> {
             context,
           ).showSnackBar(SnackBar(content: Text('$message')));
         }
-        if (reason == 'expired') {}
+        if (reason == 'expired') {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('OTP expired. Please request a new code.'),
+              ),
+            );
+          }
+          _startResendCooldown();
+        }
       }
     } catch (e) {
       if (mounted)

--- a/lib/features/auth/presentation/screens/otp_request_screen.dart
+++ b/lib/features/auth/presentation/screens/otp_request_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app_chat/shared/services/otp_service.dart';
+import 'package:flutter_app_chat/core/config.dart';
+import '../models/otp_args.dart';
+import 'otp_input_screen.dart';
+import '../../domain/entities/user_entity.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/auth_bloc.dart';
+import '../bloc/auth_event.dart';
+
+class OtpRequestScreen extends StatefulWidget {
+  final OtpArgs? initialArgs;
+  const OtpRequestScreen({Key? key, this.initialArgs}) : super(key: key);
+
+  @override
+  State<OtpRequestScreen> createState() => _OtpRequestScreenState();
+}
+
+class _OtpRequestScreenState extends State<OtpRequestScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  late final OtpService _otpService;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _otpService = OtpService(AppConfig.backendBaseUrl);
+    if (widget.initialArgs != null) {
+      _emailController.text = widget.initialArgs!.email;
+    }
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Request OTP')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 24),
+              TextField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                autofillHints: const [AutofillHints.email],
+                decoration: const InputDecoration(labelText: 'Email'),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _isLoading ? null : _sendOtp,
+                child: _isLoading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(
+                          color: Colors.white,
+                          strokeWidth: 2,
+                        ),
+                      )
+                    : const Text('Send OTP'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _sendOtp() async {
+    final email = _emailController.text.trim();
+    if (email.isEmpty) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Please enter your email')));
+      return;
+    }
+    setState(() => _isLoading = true);
+    try {
+      await _otpService.sendOtp(email);
+      if (!mounted) return;
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => OtpInputScreen(
+            onConfirm: (otp) {
+              final init = widget.initialArgs;
+              final user = UserEntity(
+                uid: '',
+                email: email,
+                username: init?.username ?? '',
+                phoneNumber: init?.phoneNumber ?? '',
+                birthDate: init?.birthDate ?? '',
+              );
+              final password = init?.password ?? '';
+              context.read<AuthBloc>().add(AuthSignUpRequested(user, password));
+            },
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('Failed to send OTP: $e')));
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+}

--- a/lib/features/auth/presentation/screens/otp_success_screen.dart
+++ b/lib/features/auth/presentation/screens/otp_success_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class OtpSuccessScreen extends StatelessWidget {
+  final VoidCallback? onContinue;
+  const OtpSuccessScreen({Key? key, this.onContinue}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const SizedBox(height: 64),
+              Icon(
+                Icons.check_circle_outline,
+                size: 80,
+                color: Color(0xFF377DFF),
+              ),
+              const SizedBox(height: 32),
+              const Text(
+                'Success!',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'Congratulations! You have been successfully authenticated',
+                style: TextStyle(fontSize: 15, color: Colors.grey),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF377DFF),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(24),
+                  ),
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                ),
+                onPressed: onContinue,
+                child: const Text('Continue', style: TextStyle(fontSize: 16)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -5,7 +5,8 @@ import 'package:country_picker/country_picker.dart';
 import 'login_screen.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../bloc/auth_bloc.dart';
-import '../bloc/auth_event.dart';
+import '../models/otp_args.dart';
+import 'otp_request_screen.dart';
 import '../state/auth_state.dart';
 import '../../domain/entities/user_entity.dart';
 import '../widgets/auth_text_field.dart';
@@ -238,15 +239,19 @@ class _RegisterScreenState extends State<RegisterScreen> {
                           );
                           return;
                         }
-                        final user = UserEntity(
-                          uid: '',
+                        final otpArgs = OtpArgs(
                           email: email,
+                          password: password,
                           username: name,
                           phoneNumber: '+${country.phoneCode}$phone',
                           birthDate: DateFormat('dd/MM/yyyy').format(birth),
                         );
-                        context.read<AuthBloc>().add(
-                          AuthSignUpRequested(user, password),
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) =>
+                                OtpRequestScreen(initialArgs: otpArgs),
+                          ),
                         );
                       },
                       style: ElevatedButton.styleFrom(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,7 +30,6 @@ class MyApp extends StatelessWidget {
       ),
     );
 
-    // Usecases
     final signInUseCase = SignInUseCase(authRepository);
     final signUpUseCase = SignUpUseCase(authRepository);
     final signOutUseCase = SignOutUseCase(authRepository);

--- a/lib/shared/services/otp_service.dart
+++ b/lib/shared/services/otp_service.dart
@@ -1,0 +1,45 @@
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+class OtpService {
+  final String backendUrl;
+  OtpService(this.backendUrl);
+
+  Future<void> sendOtp(String email) async {
+    final response = await http.post(
+      Uri.parse('$backendUrl/send-otp'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({'email': email}),
+    );
+    if (response.statusCode == 200) return;
+    final body = json.decode(response.body);
+    final msg = body is Map
+        ? (body['message'] ?? body['error'] ?? response.body)
+        : response.body;
+    throw Exception('Failed to send OTP: $msg');
+  }
+
+  /// Returns a map: { 'ok': bool, 'reason': String? }
+  Future<Map<String, dynamic>> verifyOtp(String email, String inputCode) async {
+    final response = await http.post(
+      Uri.parse('$backendUrl/verify-otp'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode({'email': email, 'code': inputCode}),
+    );
+    final body = response.body.isNotEmpty ? json.decode(response.body) : {};
+    if (response.statusCode == 200) return {'ok': true};
+    // normalize reasons
+    if (body is Map && body.containsKey('reason')) {
+      return {
+        'ok': false,
+        'reason': body['reason'],
+        'message': body['message'],
+      };
+    }
+    return {
+      'ok': false,
+      'reason': 'unknown',
+      'message': body is Map ? body['message'] ?? body['error'] : response.body,
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -217,7 +217,7 @@ packages:
     source: sdk
     version: "0.0.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   intl: ^0.20.2
   country_picker: ^2.0.27
   lottie: ^3.1.0
+  http: ^1.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a full OTP (One-Time Password) authentication flow to the app, including backend integration, user interface screens for requesting and entering OTPs, and service logic for sending and verifying codes. The registration process is refactored to use this OTP flow, improving both security and user experience.

**OTP Authentication Flow Implementation**

* Added `OtpService` in `lib/shared/services/otp_service.dart` to handle sending and verifying OTP codes via HTTP requests to the backend.
* Created UI screens for OTP:
  * `OtpRequestScreen` for requesting an OTP code and transitioning to OTP input.
  * `OtpInputScreen` for entering the OTP code, handling paste, resend, and verification logic.
  * `OtpSuccessScreen` to show successful authentication feedback.
* Added `OtpArgs` model to pass necessary user data between OTP screens.

**Registration Flow Refactor**

* Updated `register_screen.dart` to route users through the OTP request and input screens instead of directly signing them up, using the new `OtpArgs` model.

**Configuration and Dependencies**

* Added `AppConfig` class for backend URL configuration.
* Added `http` package dependency for backend communication.
