### PR TITLE
Feature/chat

### DIFF
--- a/lib/features/chat/presentation/screens/home_screen.dart
+++ b/lib/features/chat/presentation/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_app_chat/features/auth/presentation/bloc/auth_event.dart
 import 'package:flutter_app_chat/features/auth/presentation/state/auth_state.dart';
 import 'package:flutter_app_chat/shared/widgets/app_drawer.dart';
 import 'package:flutter_app_chat/shared/widgets/chat_list_empty.dart';
+import 'package:flutter_app_chat/shared/widgets/chat_list_view.dart';
 import 'package:flutter_app_chat/shared/widgets/chat_list_tile.dart';
 import 'package:flutter_app_chat/shared/widgets/confirm_dialog.dart';
 
@@ -19,7 +20,105 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   int _selectedIndex = 0;
-  final List<Map<String, dynamic>> chats = [];
+  final List<Map<String, dynamic>> chats = [
+    {
+      'id': '1',
+      'name': 'Daniel Atkins',
+      'lastMessage': 'The weather will be perfect for the stream tonight',
+      'time': '2:14 PM',
+      'avatarUrl': null,
+      'unreadCount': 1,
+      'isOnline': true,
+    },
+    {
+      'id': '2',
+      'name': 'Erin, Ursula, Matthew',
+      'lastMessage': 'You: The store only has (gasp!) 2% milk left',
+      'time': '2:14 PM',
+      'avatarUrl': null,
+      'unreadCount': 1,
+    },
+    {
+      'id': '3',
+      'name': 'Photographers',
+      'lastMessage': '@Philippe: Hmm, are you sure?',
+      'time': '10:16 PM',
+      'avatarUrl': null,
+      'unreadCount': 80,
+    },
+    {
+      'id': '4',
+      'name': 'Nelms, Clayton, Wagner, Morgan',
+      'lastMessage': 'You: The game went into OT, it\'s gonna be wild',
+      'time': 'Friday',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '5',
+      'name': 'Regina Jones',
+      'lastMessage': 'The class has open enrollment until the end of the month',
+      'time': '12/28/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '6',
+      'name': 'Baker Hayfield',
+      'lastMessage': '@waldo Is Cleveland nice in October?',
+      'time': '08/09/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '7',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '8',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '8',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '8',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '8',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+    {
+      'id': '8',
+      'name': 'Kaitlyn Henson',
+      'lastMessage': 'You: Can you mail my rent check?',
+      'time': '22/08/20',
+      'avatarUrl': null,
+      'unreadCount': 0,
+    },
+  ];
 
   Future<void> _handleSignOut() async {
     final confirmed = await showDialog<bool>(
@@ -48,55 +147,71 @@ class _HomeScreenState extends State<HomeScreen> {
           );
         }
       },
-      child: Scaffold(
-        drawer: AppDrawer(onSignOut: _handleSignOut, userName: 'Andrew Jones'),
-        appBar: AppBar(
-          title: const Text('Secret Chat'),
-          centerTitle: true,
-          leading: Builder(
-            builder: (context) => IconButton(
-              icon: CircleAvatar(
-                backgroundImage: AssetImage(kDefaultAvatarAsset),
-                radius: 16,
+      child: BlocBuilder<AuthBloc, AuthState>(
+        builder: (context, state) {
+          String? userName;
+          String? avatarUrl;
+          if (state is AuthAuthenticated) {
+            userName = state.user.username ?? state.user.email;
+            avatarUrl = state.user.avatarUrl;
+          }
+
+          return Scaffold(
+            drawer: AppDrawer(
+              onSignOut: _handleSignOut,
+              userName: userName,
+              avatarUrl: avatarUrl,
+            ),
+            appBar: AppBar(
+              title: const Text('Secret Chat'),
+              centerTitle: true,
+              leading: Builder(
+                builder: (context) => IconButton(
+                  icon: CircleAvatar(
+                    backgroundImage: (avatarUrl != null && avatarUrl.isNotEmpty)
+                        ? NetworkImage(avatarUrl)
+                        : AssetImage(kDefaultAvatarAsset) as ImageProvider,
+                    radius: 16,
+                  ),
+                  onPressed: () => Scaffold.of(context).openDrawer(),
+                ),
               ),
-              onPressed: () => Scaffold.of(context).openDrawer(),
+              actions: [
+                IconButton(icon: const Icon(Icons.edit), onPressed: () {}),
+              ],
             ),
-          ),
-          actions: [IconButton(icon: const Icon(Icons.edit), onPressed: () {})],
-        ),
-        body: _selectedIndex == 0 ? _buildChatList() : _buildMentions(),
-        bottomNavigationBar: BottomNavigationBar(
-          currentIndex: _selectedIndex,
-          onTap: (i) => setState(() => _selectedIndex = i),
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.chat_bubble_outline),
-              label: 'Chats',
+            body: _selectedIndex == 0 ? _buildChatList() : _buildMentions(),
+            bottomNavigationBar: BottomNavigationBar(
+              currentIndex: _selectedIndex,
+              onTap: (i) => setState(() => _selectedIndex = i),
+              items: const [
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.chat_bubble_outline),
+                  label: 'Chats',
+                ),
+                BottomNavigationBarItem(
+                  icon: Icon(Icons.alternate_email),
+                  label: 'Mentions',
+                ),
+              ],
             ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.alternate_email),
-              label: 'Mentions',
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
 
   Widget _buildChatList() {
-    if (chats.isEmpty) {
-      return ChatListEmpty(onStartChat: () {});
-    }
-    return ListView.builder(
-      itemCount: chats.length,
-      itemBuilder: (context, index) {
-        final chat = chats[index];
-        return ChatListTile(
-          name: chat['name'] ?? '',
-          lastMessage: chat['lastMessage'] ?? '',
-          time: chat['time'] ?? '',
-          onTap: () {},
-        );
+    if (chats.isEmpty) return ChatListEmpty(onStartChat: () {});
+
+    return ChatListView(
+      items: chats,
+      onTap: (id) {
+        // TODO: navigate to chat screen for id
+      },
+      onRefresh: () async {
+        // TODO: implement refresh logic; for demo, delay briefly
+        await Future.delayed(const Duration(seconds: 1));
       },
     );
   }

--- a/lib/shared/widgets/app_drawer.dart
+++ b/lib/shared/widgets/app_drawer.dart
@@ -3,8 +3,10 @@ import 'package:flutter/material.dart';
 
 class AppDrawer extends StatelessWidget {
   final VoidCallback? onSignOut;
-  final String userName;
-  const AppDrawer({super.key, this.onSignOut, required this.userName});
+  final String? userName;
+  final String? avatarUrl;
+
+  const AppDrawer({super.key, this.onSignOut, this.userName, this.avatarUrl});
 
   @override
   Widget build(BuildContext context) {
@@ -19,11 +21,14 @@ class AppDrawer extends StatelessWidget {
                 children: [
                   CircleAvatar(
                     radius: 28,
-                    backgroundImage: AssetImage(kDefaultAvatarAsset),
+                    backgroundImage:
+                        (avatarUrl != null && avatarUrl!.isNotEmpty)
+                        ? NetworkImage(avatarUrl!) as ImageProvider
+                        : AssetImage(kDefaultAvatarAsset),
                   ),
                   const SizedBox(width: 12),
                   Text(
-                    userName,
+                    userName ?? 'Guest',
                     style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       fontSize: 18,

--- a/lib/shared/widgets/chat_list_view.dart
+++ b/lib/shared/widgets/chat_list_view.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'optimized_chat_list_tile.dart';
+
+typedef ChatTapCallback = void Function(String id);
+
+class ChatListView extends StatelessWidget {
+  final List<Map<String, dynamic>> items;
+  final ChatTapCallback? onTap;
+  final RefreshCallback? onRefresh;
+  final double? itemExtent;
+
+  const ChatListView({
+    super.key,
+    required this.items,
+    this.onTap,
+    this.onRefresh,
+    this.itemExtent = 76,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // Use RefreshIndicator for pull-to-refresh UX
+    return RefreshIndicator(
+      onRefresh: onRefresh ?? () async {},
+      child: ListView.separated(
+        physics: const AlwaysScrollableScrollPhysics(),
+        itemCount: items.length,
+        separatorBuilder: (context, index) =>
+            const Divider(height: 1, indent: 80),
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return SizedBox(
+            height: itemExtent,
+            child: OptimizedChatListTile(
+              id: item['id'] ?? index.toString(),
+              name: item['name'] ?? '',
+              lastMessage: item['lastMessage'] ?? '',
+              time: item['time'] ?? '',
+              avatarUrl: item['avatarUrl'],
+              unreadCount: item['unreadCount'] ?? 0,
+              isOnline: item['isOnline'] ?? false,
+              onTap: () => onTap?.call(item['id'] ?? index.toString()),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/optimized_chat_list_tile.dart
+++ b/lib/shared/widgets/optimized_chat_list_tile.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import 'chat_list_tile.dart';
+
+class OptimizedChatListTile extends StatelessWidget {
+  final String id;
+  final String name;
+  final String lastMessage;
+  final String time;
+  final String? avatarUrl;
+  final int unreadCount;
+  final bool isOnline;
+  final VoidCallback? onTap;
+
+  const OptimizedChatListTile({
+    super.key,
+    required this.id,
+    required this.name,
+    required this.lastMessage,
+    required this.time,
+    this.avatarUrl,
+    this.unreadCount = 0,
+    this.isOnline = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // RepaintBoundary reduces repaints when parent updates.
+    return RepaintBoundary(
+      key: ValueKey('chat_tile_\$id'),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: 12.0,
+              vertical: 8.0,
+            ),
+            child: Row(
+              children: [
+                // Avatar with online indicator
+                Stack(
+                  children: [
+                    ClipOval(
+                      child: SizedBox(
+                        width: 52,
+                        height: 52,
+                        child: avatarUrl != null && avatarUrl!.isNotEmpty
+                            ? FadeInImage.assetNetwork(
+                                placeholder: kDefaultAvatarAsset,
+                                image: avatarUrl!,
+                                fit: BoxFit.cover,
+                              )
+                            : Image.asset(
+                                kDefaultAvatarAsset,
+                                fit: BoxFit.cover,
+                              ),
+                      ),
+                    ),
+                    if (isOnline)
+                      Positioned(
+                        right: 0,
+                        bottom: 0,
+                        child: Container(
+                          width: 12,
+                          height: 12,
+                          decoration: BoxDecoration(
+                            color: Colors.greenAccent.shade400,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: Theme.of(context).scaffoldBackgroundColor,
+                              width: 2,
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(width: 12),
+                // Expanded content area
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              name,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 16,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        lastMessage,
+                        style: TextStyle(color: Colors.grey[600], fontSize: 14),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                // Time and unread badge
+                Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      time,
+                      style: TextStyle(color: Colors.grey[500], fontSize: 12),
+                    ),
+                    const SizedBox(height: 8),
+                    if (unreadCount > 0)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 8,
+                          vertical: 4,
+                        ),
+                        decoration: BoxDecoration(
+                          color: Colors.redAccent,
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          unreadCount > 99 ? '99+' : unreadCount.toString(),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      )
+                    else
+                      const SizedBox.shrink(),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request refactors the chat list display in the home screen to use a new, optimized chat list view and tile widget, improves avatar and user name handling in the drawer and app bar, and introduces demo chat data for development purposes. The most significant changes are grouped below.

**Chat List Rendering Improvements:**

* Replaced the manual `ListView.builder` chat list in `home_screen.dart` with the new `ChatListView` widget, which uses `OptimizedChatListTile` for better performance and UI consistency. The new widget supports pull-to-refresh and passes chat data and callbacks in a more modular way.

**Demo Data and State Handling:**

* Added a set of demo chat data to the `chats` list in `home_screen.dart` to facilitate UI development and preview. 
* Updated the home screen to use `BlocBuilder` for `AuthState`, allowing dynamic display of the authenticated user's name and avatar in both the drawer and app bar.

**Drawer and Avatar Enhancements:**

* Refactored `AppDrawer` to accept nullable `userName` and `avatarUrl` parameters, and improved avatar display logic to show the user's avatar if available, falling back to a default asset otherwise.

**Imports and Code Organization:**

* Added missing imports for new widgets (`chat_list_view.dart`) in `home_screen.dart` to support the new chat list implementation. 